### PR TITLE
Remove offending `logger.info` call which wasn't passing a string as …

### DIFF
--- a/lib/logstash/inputs/log4j2.rb
+++ b/lib/logstash/inputs/log4j2.rb
@@ -112,7 +112,6 @@ class LogStash::Inputs::Log4j2 < LogStash::Inputs::Base
         output_queue << event
       end # loop do
     rescue => e
-      @logger.info(e)
       @logger.info("Closing connection", :client => socket.peer,
                     :exception => e)
     rescue Timeout::Error


### PR DESCRIPTION
…the first argument.

The exception is actually already logged in the subsequent call.